### PR TITLE
[UX] Auto exit

### DIFF
--- a/src/app/sagas/index.js
+++ b/src/app/sagas/index.js
@@ -1,8 +1,11 @@
 import { takeLatest } from 'redux-saga/effects';
-import { fetchUsers } from './users';
+import { fetchUsers, goToDetails, goToApplicants } from './users';
+import { FETCH_USERS, SET_CURRENT_USER, CHANGE_USER_STATUS } from '../constants/users';
 
 function* rootSaga() {
-  yield takeLatest('FETCH_USERS', fetchUsers);
+  yield takeLatest(FETCH_USERS, fetchUsers);
+  yield takeLatest(SET_CURRENT_USER, goToDetails);
+  yield takeLatest(CHANGE_USER_STATUS, goToApplicants);
 }
 
 export default rootSaga;

--- a/src/app/sagas/users.js
+++ b/src/app/sagas/users.js
@@ -1,4 +1,6 @@
 import { call, put } from 'redux-saga/effects';
+import { push } from 'react-router-redux';
+
 import { getUsers } from '../api';
 import { FETCH_USERS_SUCCEEDED, FETCH_USERS_FAILED } from '../constants/users';
 
@@ -9,4 +11,12 @@ export function* fetchUsers({ payload }) {
   } catch (error) {
     yield put({ type: FETCH_USERS_FAILED, error });
   }
+}
+
+export function* goToDetails() {
+  yield put(push('/details'));
+}
+
+export function* goToApplicants() {
+  yield put(push('/applicants'));
 }

--- a/src/app/views/Applicants/index.js
+++ b/src/app/views/Applicants/index.js
@@ -2,7 +2,6 @@ import { isEmpty } from 'ramda';
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { push } from 'react-router-redux';
 
 import { usersPropType } from '../customPropTypes';
 import { usersSelector } from '../../reducers/users';
@@ -28,7 +27,6 @@ class Applicants extends Component {
     const onClick = (user) => () => {
       if (user) {
         dispatch({ type: SET_CURRENT_USER, payload: user.id });
-        dispatch(push('/details'));
       }
     };
 


### PR DESCRIPTION
Currently, when the status of an applicant has been changed, our user needs to manually exit the `/details` page. This PR attempts to implement an "auto exit" behaviour such that when the user changes the status of an applicant, it automatically returns to the `/applicants` page.